### PR TITLE
[최준영] 회원가입 기능 추가

### DIFF
--- a/board/src/main/java/study/board/BoardApplication.java
+++ b/board/src/main/java/study/board/BoardApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class BoardApplication {
 

--- a/board/src/main/java/study/board/confing/JpaAuditingConfig.java
+++ b/board/src/main/java/study/board/confing/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package study.board.confing;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/board/src/main/java/study/board/controller/api/UserController.java
+++ b/board/src/main/java/study/board/controller/api/UserController.java
@@ -1,0 +1,23 @@
+package study.board.controller.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import study.board.service.UserService;
+
+import static study.board.controller.api.dto.UserDto.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/join")
+    public ResponseEntity join(@Validated @RequestBody UserJoinRequest userJoinRequest) {
+        String result = userService.join(userJoinRequest.toEntity());
+        return ResponseEntity.ok().body("회원가입 성공");
+    }
+}

--- a/board/src/main/java/study/board/controller/api/dto/UserDto.java
+++ b/board/src/main/java/study/board/controller/api/dto/UserDto.java
@@ -1,0 +1,31 @@
+package study.board.controller.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+import study.board.entity.User;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Pattern;
+
+public class UserDto {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class UserJoinRequest {
+
+        @Email
+        private String email;
+
+        @Length(min = 8, max = 15)
+        //regular expression, ^:문자열 시작, \S:공백을 제외한 모든 문자, $:문자열의 끝
+        @Pattern(regexp = "^\\S+$", message = "공백을 포함할 수 없습니다.")
+        private String password;
+
+        public User toEntity() {
+            return User.createUser(email, password);
+        }
+    }
+}

--- a/board/src/main/java/study/board/entity/User.java
+++ b/board/src/main/java/study/board/entity/User.java
@@ -1,0 +1,31 @@
+package study.board.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+    @Column(length = 15)
+    private String password;
+
+    private User(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public static User createUser(String email, String password) {
+        return new User(email, password);
+    }
+}

--- a/board/src/main/java/study/board/exception/EmailDupException.java
+++ b/board/src/main/java/study/board/exception/EmailDupException.java
@@ -1,0 +1,23 @@
+package study.board.exception;
+
+public class EmailDupException extends RuntimeException {
+    public EmailDupException() {
+        super();
+    }
+
+    public EmailDupException(String message) {
+        super(message);
+    }
+
+    public EmailDupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EmailDupException(Throwable cause) {
+        super(cause);
+    }
+
+    protected EmailDupException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/board/src/main/java/study/board/exhandler/BaseErrorResult.java
+++ b/board/src/main/java/study/board/exhandler/BaseErrorResult.java
@@ -3,9 +3,10 @@ package study.board.exhandler;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
-@Data
+@Getter
 @SuperBuilder
 @Schema(description = "공통 오류 응답")
 public class BaseErrorResult {

--- a/board/src/main/java/study/board/exhandler/ErrorResult.java
+++ b/board/src/main/java/study/board/exhandler/ErrorResult.java
@@ -1,16 +1,18 @@
 package study.board.exhandler;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Map;
 
+@Getter
 @SuperBuilder
 @Schema(description = "검증 오류 응답")
 public class ErrorResult extends BaseErrorResult {
 
     @Schema(description = "필드와 검증 내용", example = "error")
-    private Map<String, String> errors;
+    private Map<String, String> details;
 }

--- a/board/src/main/java/study/board/exhandler/advice/ExceptionManager.java
+++ b/board/src/main/java/study/board/exhandler/advice/ExceptionManager.java
@@ -8,8 +8,8 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import study.board.exception.BoardNotFoundException;
+import study.board.exception.EmailDupException;
 import study.board.exhandler.BaseErrorResult;
 import study.board.exhandler.ErrorResult;
 
@@ -18,7 +18,17 @@ import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
-public class BoardExControllerAdvice {
+public class ExceptionManager {
+
+
+    @ExceptionHandler
+    public ResponseEntity<BaseErrorResult> emailDupExHandler(EmailDupException e) {
+        BaseErrorResult errorResult = BaseErrorResult.builder()
+                .errorCode(GlobalErrorCode.CONFLICT.getCode())
+                .errorMessage(e.getMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResult);
+    }
 
     @ExceptionHandler
     public ResponseEntity<BaseErrorResult> boardNotFoundExHandler(BoardNotFoundException e) {
@@ -41,11 +51,10 @@ public class BoardExControllerAdvice {
                             String errorMessage = error.getDefaultMessage();
                             errors.put(fieldName, errorMessage);
                         });
-
         ErrorResult errorResult = ErrorResult.builder()
                 .errorCode(GlobalErrorCode.VALIDATION.getCode())
                 .errorMessage(GlobalErrorCode.VALIDATION.getMessage())
-                .errors(errors)
+                .details(errors)
                 .build();
         return ResponseEntity.badRequest().body(errorResult);
     }
@@ -65,7 +74,7 @@ public class BoardExControllerAdvice {
         ErrorResult errorResult = ErrorResult.builder()
                 .errorCode(GlobalErrorCode.QUERY_VALIDATION.getCode())
                 .errorMessage(GlobalErrorCode.QUERY_VALIDATION.getMessage())
-                .errors(errors)
+                .details(errors)
                 .build();
         return ResponseEntity.badRequest().body(errorResult);
     }

--- a/board/src/main/java/study/board/exhandler/advice/GlobalErrorCode.java
+++ b/board/src/main/java/study/board/exhandler/advice/GlobalErrorCode.java
@@ -4,7 +4,10 @@ public enum GlobalErrorCode {
     INTERNAL_SERVER("000","내부 오류"),
     NOT_FOUND("001","존재하지 않는 데이터입니다."),
     VALIDATION("002","validation error"),
-    QUERY_VALIDATION("003","query validation error");
+    QUERY_VALIDATION("003","query validation error"),
+
+    CONFLICT("409", "conflict");
+
 
     private final String code;
     private final String message;

--- a/board/src/main/java/study/board/repository/UserRepository.java
+++ b/board/src/main/java/study/board/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package study.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import study.board.entity.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/board/src/main/java/study/board/service/UserService.java
+++ b/board/src/main/java/study/board/service/UserService.java
@@ -1,0 +1,31 @@
+package study.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import study.board.entity.User;
+import study.board.exception.EmailDupException;
+import study.board.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public String join(User user) {
+
+        //email 중복 check
+        userRepository.findByEmail(user.getEmail())
+                .ifPresent(u -> {
+                    throw new EmailDupException(user.getEmail() + "이 이미 존재합니다.");
+                });
+
+        //저장
+        userRepository.save(user);
+
+
+        return "SUCCESS";
+    }
+}

--- a/board/src/main/resources/application-local.yml
+++ b/board/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
       use-new-id-generator-mappings: false #hibernate 5의 AUTO의 전략이 TABLE
     properties:
       hibernate:

--- a/board/src/main/resources/application.yml
+++ b/board/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
       use-new-id-generator-mappings: false #hibernate 5의 AUTO의 전략이 TABLE
     properties:
       hibernate:
@@ -16,7 +16,7 @@ spring:
         default_batch_fetch_size: 100
         dialect: org.hibernate.dialect.MySQL8Dialect
   profiles:
-    default: prod
+    default: local
 #    active: local
 
 

--- a/board/src/test/java/study/board/controller/api/UserControllerTest.java
+++ b/board/src/test/java/study/board/controller/api/UserControllerTest.java
@@ -1,0 +1,77 @@
+package study.board.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import study.board.exception.EmailDupException;
+import study.board.service.BoardService;
+import study.board.service.UserService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static study.board.controller.api.dto.UserDto.*;
+
+@WebMvcTest(controllers = UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    UserService userService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    public void join() throws Exception {
+        String email = "cjy@cjy.com";
+        String password = "1q2w3e4r";
+
+        mockMvc.perform(post("/api/v1/users/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(UserJoinRequest.builder()
+                                .email(email)
+                                .password(password)
+                                .build()
+                                )
+                        )
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - email 중복")
+    public void join_fail() throws Exception {
+        String email = "cjy@cjy.com";
+        String password = "1q2w3e4r";
+
+        when(userService.join(any()))
+                .thenThrow(new EmailDupException("사용중인 이메일주소입니다."));
+
+        mockMvc.perform(post("/api/v1/users/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(UserJoinRequest.builder()
+                                .email(email)
+                                .password(password)
+                                .build()
+                                )
+                        )
+                )
+                .andDo(print())
+                .andExpect(status().isConflict());
+
+    }
+
+}


### PR DESCRIPTION
### ✅ 학습 목표

- JWT에 대한 이해
- JWT를 활용한 인증, 인가 구현
- 로그인, 회원가입 로직 이해

### ✅ 요구 사항 1단계

<aside>
💬 Tip : ‘회원가입 기능’ → ‘로그인 기능’ → ‘내 정보 조회 기능’ 순서로 구현해라!


1. **회원가입 기능**
- 회원가입 시 `이메일`, `패스워드`를 받아서, DB에 `이메일`, `패스워드`, `회원 가입 시간`을 저장해야 한다.
- 유저에 대한 정보가 저장될 때, `id`(PK, primary key)도 같이 Auto-increment 형식으로 저장돼야 한다.
- `이메일`에 반드시 `@`가 1개만 포함되어 있어야 한다.
- `이메일`에 공백이 포함될 수 없다.
- 중복된 `이메일`이 존재할 수 없다.
- `패스워드`에 공백이 포함될 수 없다.
- `패스워드`는 8자 이상 15자 이하여야 한다.
- (비밀번호는 암호화하지 않고 그대로 저장한다. 암호화하는 건 뒤에서 구현하게 된다.)

1. **로그인 기능**
- 로그인 시 `이메일`, `패스워드` 값을 받는다.
- 로그인에 성공했을 때, JWT를 활용해 Access Token 값을 응답해야 한다.
- JWT의 payload에는 사용자의 `id`(PK, primary key)가 반드시 담겨있어야 한다.

1. **내 정보 조회 기능**
- 사용자가 요청을 보낼 때 Header에 JWT 토큰을 넘기도록 한다.
- Header에 JWT 토큰이 담겨있지 않다면 에러로 응답한다.
- Header에 담겨있는 JWT 토큰이 올바르지 않거나 조작되었다면 에러로 응답한다.
- Header에 담겨있는 JWT 토큰의 만료기간이 지났다면 에러로 응답한다.
- Haeder에 담겨있는 JWT 토큰이 올바르다면, JWT 토큰의 payload에 담겨있는 사용자의 `id`(PK, primary key)를 활용해라.
- 응답값에는 `id`(PK, primary key), `이메일`, `회원 가입 시간`이 포함되어야 한다.
- 응답값에는 `패스워드`가 포함되면 안 된다.